### PR TITLE
Remove install instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,6 @@ support is wanted just pass in None. The library rust-openssl is used to support
 [![Build Status](https://travis-ci.org/mattnenterprise/rust-pop3.svg)](https://travis-ci.org/mattnenterprise/rust-pop3)
 [![crates.io](http://meritbadge.herokuapp.com/pop3)](https://crates.io/crates/pop3)
 
-### Installation
-
-Add pop3 via your `Cargo.toml`:
-```toml
-[dependencies]
-pop3 = "*"
-```
-
 ### Usage
 ```rust
 extern crate pop3;


### PR DESCRIPTION
Removing install instructions from README.
It should be abvious from the crates badge
how users should add this library to their
Cargo.toml.